### PR TITLE
Use #!/usr/bin/env instead of hard coded path

### DIFF
--- a/examples/custom-build1.cpp
+++ b/examples/custom-build1.cpp
@@ -1,4 +1,4 @@
-#!/usr/local/bin/build-n-run
+#!/usr/bin/env build-n-run
 //!cc= gcc {source} -o {target} -std=c++17 -march=native -O2 -fno-rtti -flto -Wall -Wextra -I~/include
 #include <cstdio>
 

--- a/examples/custom-build2.cpp
+++ b/examples/custom-build2.cpp
@@ -1,4 +1,4 @@
-#!/usr/local/bin/build-n-run
+#!/usr/bin/env build-n-run
 //!cc+= -g
 #include <cstdio>
 

--- a/examples/hello.cpp
+++ b/examples/hello.cpp
@@ -1,4 +1,4 @@
-#!/usr/local/bin/build-n-run
+#!/usr/bin/env build-n-run
 #include <cstdio>
 
 int main() {


### PR DESCRIPTION
When installed with `install-user` the examples doesn't work because of the hard coded path this changes make then work independent of the installation path.